### PR TITLE
Add QUARTIQ Stabilizer + Booster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,9 @@ Work in progress crates. Help the authors make these crates awesome!
 - [anne-key](https://github.com/ah-/anne-key): Alternate keyboard firmware for the Obins ANNE Pro
 - [μLA](https://github.com/dotcypress/ula): Micro Logic Analyzer for RP2040
 - [air-gradient-pro-rs](https://github.com/jonlamb-gh/air-gradient-pro-rs): Bootloader, firmware and CLI tools for the AirGradient PRO
+- [Stabilizer](https://github.com/quartiq/stabilizer): Firmware for a DSP tool used in quantum physics experimentation, includes telemetry via MQTT and run-time configuration
+- [Booster](https://github.com/quartiq/booster): Firmware for an RF power amplifier, including telemetry via MQTT and run-time configuration
+
 
 ## Old books, blogs and training materials
 


### PR DESCRIPTION
Adds Stabilizer (https://github.com/quartiq/stabilizer) and Booster (https://github.com/quartiq/booster) from QUARTIQ to embedded example projects

I've pointed lots of people to these projects on Matrix as examples of complex RTIC, ethernet, MQTT, run-time configuration etc.